### PR TITLE
stdlib: add env, bitflags, and rate_limit modules

### DIFF
--- a/stdlib/bitflags.ltl
+++ b/stdlib/bitflags.ltl
@@ -1,0 +1,102 @@
+// Lateralus Standard Library — Bit Flags
+// Type-safe bitflag operations for system programming
+
+/// A set of named bit flags backed by a u64
+struct BitFlags {
+    value: u64,
+    names: [(str, u64)],
+}
+
+impl BitFlags {
+    /// Create an empty flag set
+    pub fn new() -> BitFlags {
+        BitFlags { value: 0, names: [] }
+    }
+
+    /// Create from a raw integer value
+    pub fn from_raw(value: u64) -> BitFlags {
+        BitFlags { value, names: [] }
+    }
+
+    /// Define a named flag
+    pub fn define(mut self, name: str, bit: u64) -> BitFlags {
+        self.names.push((name, 1u64 << bit))
+        self
+    }
+
+    /// Set a flag by name
+    pub fn set(mut self, name: str) -> Result<BitFlags, str> {
+        let mask = self.names
+            |> find(|(n, _)| n == name)
+            |> map(|(_, m)| m)
+            |> ok_or("Unknown flag: {name}")?
+        self.value |= mask
+        Ok(self)
+    }
+
+    /// Clear a flag by name
+    pub fn clear(mut self, name: str) -> Result<BitFlags, str> {
+        let mask = self.names
+            |> find(|(n, _)| n == name)
+            |> map(|(_, m)| m)
+            |> ok_or("Unknown flag: {name}")?
+        self.value &= !mask
+        Ok(self)
+    }
+
+    /// Toggle a flag by name
+    pub fn toggle(mut self, name: str) -> Result<BitFlags, str> {
+        let mask = self.names
+            |> find(|(n, _)| n == name)
+            |> map(|(_, m)| m)
+            |> ok_or("Unknown flag: {name}")?
+        self.value ^= mask
+        Ok(self)
+    }
+
+    /// Check if a flag is set
+    pub fn has(self, name: str) -> bool {
+        self.names
+            |> find(|(n, _)| n == name)
+            |> map(|(_, m)| self.value & m != 0)
+            |> unwrap_or(false)
+    }
+
+    /// Check if all given flags are set
+    pub fn has_all(self, names: [str]) -> bool {
+        names |> all(|n| self.has(n))
+    }
+
+    /// Check if any of the given flags are set
+    pub fn has_any(self, names: [str]) -> bool {
+        names |> any(|n| self.has(n))
+    }
+
+    /// Get raw value
+    pub fn raw(self) -> u64 { self.value }
+
+    /// Union of two flag sets
+    pub fn union(self, other: BitFlags) -> BitFlags {
+        BitFlags { value: self.value | other.value, names: self.names }
+    }
+
+    /// Intersection of two flag sets
+    pub fn intersect(self, other: BitFlags) -> BitFlags {
+        BitFlags { value: self.value & other.value, names: self.names }
+    }
+
+    /// List all active flag names
+    pub fn active(self) -> [str] {
+        self.names
+            |> filter(|(_, m)| self.value & m != 0)
+            |> map(|(n, _)| n)
+            |> collect
+    }
+
+    /// Display as a human-readable string
+    pub fn to_string(self) -> str {
+        let flags = self.active()
+        if flags.is_empty() { "(none)" }
+        else { flags |> join(" | ") }
+    }
+}

--- a/stdlib/env.ltl
+++ b/stdlib/env.ltl
@@ -1,0 +1,59 @@
+// Lateralus Standard Library — Environment Variables
+// Access and manipulate process environment
+
+/// Get an environment variable, returning None if not set
+pub fn get(key: str) -> Option<str> {
+    __builtin_env_get(key)
+}
+
+/// Get an environment variable with a default fallback
+pub fn get_or(key: str, default: str) -> str {
+    get(key) |> unwrap_or(default)
+}
+
+/// Set an environment variable for the current process
+pub fn set(key: str, value: str) {
+    __builtin_env_set(key, value)
+}
+
+/// Remove an environment variable
+pub fn remove(key: str) {
+    __builtin_env_remove(key)
+}
+
+/// Check if an environment variable is set
+pub fn has(key: str) -> bool {
+    get(key) |> is_some
+}
+
+/// Get all environment variables as key-value pairs
+pub fn all() -> [(str, str)] {
+    __builtin_env_all()
+}
+
+/// Get the current working directory
+pub fn cwd() -> Result<str, str> {
+    __builtin_env_cwd()
+}
+
+/// Get the home directory of the current user
+pub fn home() -> Option<str> {
+    get("HOME") |> or_else(|| get("USERPROFILE"))
+}
+
+/// Get the system PATH as a list of directories
+pub fn path_dirs() -> [str] {
+    let sep = if sys::is_windows() { ";" } else { ":" }
+    get_or("PATH", "")
+        |> split(sep)
+        |> filter(|s| s.len() > 0)
+        |> collect
+}
+
+/// Expand environment variables in a string
+/// Replaces $VAR and ${VAR} patterns
+pub fn expand(template: str) -> str {
+    template
+        |> regex::replace_all(r"\$\{([^}]+)\}", |m| get_or(m.group(1), ""))
+        |> regex::replace_all(r"\$([A-Za-z_][A-Za-z0-9_]*)", |m| get_or(m.group(1), ""))
+}

--- a/stdlib/rate_limit.ltl
+++ b/stdlib/rate_limit.ltl
@@ -1,0 +1,99 @@
+// Lateralus Standard Library — Rate Limiter
+// Token bucket rate limiting for APIs and network operations
+
+import stdlib::time
+import stdlib::sync::Mutex
+
+/// Token bucket rate limiter
+struct RateLimiter {
+    capacity: u64,
+    tokens: f64,
+    refill_rate: f64,    // tokens per second
+    last_refill: u64,    // timestamp in ms
+    mutex: Mutex<()>,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter
+    /// capacity: max tokens in the bucket
+    /// per_second: how many tokens are added per second
+    pub fn new(capacity: u64, per_second: f64) -> RateLimiter {
+        RateLimiter {
+            capacity,
+            tokens: capacity as f64,
+            refill_rate: per_second,
+            last_refill: time::now_ms(),
+            mutex: Mutex::new(()),
+        }
+    }
+
+    /// Try to consume one token. Returns true if allowed.
+    pub fn try_acquire(mut self) -> bool {
+        self.try_acquire_n(1)
+    }
+
+    /// Try to consume n tokens. Returns true if allowed.
+    pub fn try_acquire_n(mut self, n: u64) -> bool {
+        let _lock = self.mutex.lock()
+        self.refill()
+
+        if self.tokens >= n as f64 {
+            self.tokens -= n as f64
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wait until a token is available, then consume it
+    pub async fn acquire(mut self) {
+        loop {
+            if self.try_acquire() { return }
+            let wait_ms = self.time_until_available(1)
+            time::sleep_ms(wait_ms).await
+        }
+    }
+
+    /// Get the time in ms until n tokens will be available
+    pub fn time_until_available(self, n: u64) -> u64 {
+        let _lock = self.mutex.lock()
+        let needed = n as f64 - self.tokens
+        if needed <= 0.0 { return 0 }
+        ((needed / self.refill_rate) * 1000.0) as u64 + 1
+    }
+
+    /// Get current number of available tokens
+    pub fn available(mut self) -> u64 {
+        let _lock = self.mutex.lock()
+        self.refill()
+        self.tokens as u64
+    }
+
+    /// Reset the limiter to full capacity
+    pub fn reset(mut self) {
+        let _lock = self.mutex.lock()
+        self.tokens = self.capacity as f64
+        self.last_refill = time::now_ms()
+    }
+
+    /// Internal: refill tokens based on elapsed time
+    fn refill(mut self) {
+        let now = time::now_ms()
+        let elapsed = (now - self.last_refill) as f64 / 1000.0
+        self.tokens = f64::min(
+            self.capacity as f64,
+            self.tokens + elapsed * self.refill_rate,
+        )
+        self.last_refill = now
+    }
+}
+
+/// Convenience: create a limiter allowing n requests per second
+pub fn per_second(n: u64) -> RateLimiter {
+    RateLimiter::new(n, n as f64)
+}
+
+/// Convenience: create a limiter allowing n requests per minute
+pub fn per_minute(n: u64) -> RateLimiter {
+    RateLimiter::new(n, n as f64 / 60.0)
+}


### PR DESCRIPTION
## Summary

Adds three new standard library modules, expanding the stdlib per #3.

### New Modules

#### `stdlib/env.ltl` — Environment Variables
- `get`, `set`, `remove`, `has` — Core env var operations
- `get_or` — Get with default fallback
- `all` — List all variables as key-value pairs
- `cwd`, `home` — Directory helpers
- `path_dirs` — Parse PATH into a list using pipeline
- `expand` — Expand `$VAR` and `${VAR}` in template strings

#### `stdlib/bitflags.ltl` — Type-Safe Bit Flags
- Named flag definitions with bit positions
- `set`, `clear`, `toggle`, `has`, `has_all`, `has_any`
- Set operations: `union`, `intersect`
- `active` — List set flags, `to_string` — Human-readable display
- Pipeline-native design throughout

#### `stdlib/rate_limit.ltl` — Token Bucket Rate Limiter
- Configurable capacity and refill rate
- `try_acquire` / `try_acquire_n` — Non-blocking
- `acquire` — Async blocking until token available
- `per_second` / `per_minute` — Convenience constructors
- Thread-safe via Mutex

### Related Issue

Ref: #3 (Standard library expansion)

### Testing

Each module follows existing stdlib patterns and conventions.