### PR TITLE
ci(linguist): track unique repos (not files) as the eligibility signal

### DIFF
--- a/docs/linguist/meta/repo-count-badge.json
+++ b/docs/linguist/meta/repo-count-badge.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "linguist eligibility",
-  "message": "1248 / 200 \u2705",
-  "color": "brightgreen",
+  "message": "104 / 200",
+  "color": "yellow",
   "cacheSeconds": 3600
 }

--- a/docs/linguist/meta/repo-count.jsonl
+++ b/docs/linguist/meta/repo-count.jsonl
@@ -1,2 +1,3 @@
 {"ts":"2026-04-23T17:01:46Z","total":1248,"community":0,"threshold":200,"fallback":false}
 {"ts":"2026-04-23T17:08:46Z","total":1248,"community":5616,"threshold":200,"fallback":false}
+{"ts":"2026-04-23T22:15:34Z","total":1248,"community":5616,"unique_repos":104,"repos_tagged":0,"threshold":200,"fallback":false}

--- a/docs/linguist/scripts/count-ltl-repos.sh
+++ b/docs/linguist/scripts/count-ltl-repos.sh
@@ -19,6 +19,7 @@ mkdir -p "$(dirname "$OUT")"
 q_all="extension:ltl"
 q_community="extension:ltl+NOT+user:bad-antics"
 q_repo_fallback="lateralus+in:name,description,readme"
+q_repo_lang="language:Lateralus"
 
 fetch() {
   # Returns total_count or empty string on any non-2xx.
@@ -37,8 +38,33 @@ fetch_repos() {
      | jq -r '.total_count // empty' 2>/dev/null
 }
 
+# Count unique repos containing .ltl files by paging code-search results
+# (max 1000 items = 10 pages of 100). This is what Linguist actually cares
+# about — 200 unique :user/:repo pairs, not 200 files.
+fetch_unique_repos() {
+  local query="$1"
+  local page seen
+  seen="$(mktemp)"
+  for page in 1 2 3 4 5 6 7 8 9 10; do
+    local body
+    body=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 "https://api.github.com/search/code?q=${query}&per_page=100&page=${page}" 2>/dev/null) || break
+    echo "$body" | jq -r '.items[]?.repository.full_name' >> "$seen" 2>/dev/null || true
+    local got
+    got=$(echo "$body" | jq -r '.items | length // 0' 2>/dev/null)
+    [ "${got:-0}" -lt 100 ] && break
+    sleep 2   # be kind to secondary rate limits
+  done
+  sort -u "$seen" | grep -c '^' || echo 0
+  rm -f "$seen"
+}
+
 all=$(fetch "$q_all" || true)
 community=$(fetch "$q_community" || true)
+unique_repos=""
+repos_tagged=$(fetch_repos "$q_repo_lang" || true)
 fallback_used="false"
 
 # code-search requires extra perms in Actions and is rate-limited; fall back
@@ -47,13 +73,18 @@ if [ -z "${all:-}" ]; then
   all=$(fetch_repos "$q_repo_fallback" || true)
   community="${all:-0}"
   fallback_used="true"
+else
+  # Only try unique-repo counting when code-search is actually working.
+  unique_repos=$(fetch_unique_repos "$q_all" || true)
 fi
 
 all="${all:-0}"
 community="${community:-0}"
+unique_repos="${unique_repos:-0}"
+repos_tagged="${repos_tagged:-0}"
 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-printf '{"ts":"%s","total":%s,"community":%s,"threshold":200,"fallback":%s}\n' \
-       "$ts" "$all" "$community" "$fallback_used" >> "$OUT"
+printf '{"ts":"%s","total":%s,"community":%s,"unique_repos":%s,"repos_tagged":%s,"threshold":200,"fallback":%s}\n' \
+       "$ts" "$all" "$community" "$unique_repos" "$repos_tagged" "$fallback_used" >> "$OUT"
 
-echo "counted  total=$all  community=$community  fallback=$fallback_used  (threshold=200)"
+echo "counted  files=$all  community=$community  unique_repos=$unique_repos  repos_tagged=$repos_tagged  fallback=$fallback_used  (threshold=200)"

--- a/docs/linguist/scripts/update_badge.py
+++ b/docs/linguist/scripts/update_badge.py
@@ -17,6 +17,18 @@ THRESHOLD = 200
 
 
 def latest_count() -> int | None:
+    """Return the best available signal for Linguist eligibility from the
+    most recent JSONL entry.
+
+    Preference order:
+      1. unique_repos — unique :user/:repo pairs with .ltl files (what
+         Linguist actually cares about).
+      2. repos_tagged — repos GitHub already indexes as language:Lateralus.
+      3. total — raw file-hit count from code-search.
+
+    Falling back to `total` is mostly for older snapshots that predate the
+    unique-repo tracking patch.
+    """
     if not JSONL.exists():
         return None
     last = None
@@ -30,7 +42,18 @@ def latest_count() -> int | None:
             continue
     if not last:
         return None
-    return int(last.get("total", 0))
+    for field in ("unique_repos", "repos_tagged", "total"):
+        value = last.get(field)
+        if value is None:
+            continue
+        try:
+            n = int(value)
+        except (TypeError, ValueError):
+            continue
+        if n > 0:
+            return n
+    # All fields present but zero — still return 0 so the badge can show it.
+    return int(last.get("total", 0) or 0)
 
 
 def main() -> int:

--- a/tests/test_linguist_badge.py
+++ b/tests/test_linguist_badge.py
@@ -64,3 +64,66 @@ def test_uses_latest_line(tmp_path, monkeypatch):
     payload = json.loads(mod.OUT.read_text())
     assert payload["message"].startswith("199 / 200")
     assert payload["color"] == "green"  # 199/200 = 99% >= 75%
+
+
+def test_prefers_unique_repos_over_total(tmp_path, monkeypatch):
+    """unique_repos is the accurate Linguist signal; prefer it over raw file count."""
+    _patch_paths(tmp_path, monkeypatch)
+    mod.JSONL.write_text(
+        json.dumps(
+            {
+                "ts": "x",
+                "total": 1248,          # raw file hits (misleading)
+                "community": 0,
+                "unique_repos": 175,    # actual unique :user/:repo with .ltl
+                "repos_tagged": 120,    # language:Lateralus repos
+                "threshold": 200,
+            }
+        )
+        + "\n"
+    )
+    mod.main()
+    payload = json.loads(mod.OUT.read_text())
+    assert payload["message"].startswith("175 / 200")
+    assert payload["color"] == "green"  # 175/200 = 87.5% → green
+
+
+def test_falls_back_to_repos_tagged(tmp_path, monkeypatch):
+    """If unique_repos is missing/0, fall back to repos_tagged before total."""
+    _patch_paths(tmp_path, monkeypatch)
+    mod.JSONL.write_text(
+        json.dumps(
+            {
+                "ts": "x",
+                "total": 1500,
+                "unique_repos": 0,
+                "repos_tagged": 220,
+                "threshold": 200,
+            }
+        )
+        + "\n"
+    )
+    mod.main()
+    payload = json.loads(mod.OUT.read_text())
+    assert payload["message"].startswith("220 / 200")
+    assert payload["color"] == "brightgreen"
+
+
+def test_zero_unique_repos_falls_through_to_total(tmp_path, monkeypatch):
+    """A snapshot with zeroed-out new fields must still honour legacy total."""
+    _patch_paths(tmp_path, monkeypatch)
+    mod.JSONL.write_text(
+        json.dumps(
+            {
+                "ts": "x",
+                "total": 42,
+                "unique_repos": 0,
+                "repos_tagged": 0,
+                "threshold": 200,
+            }
+        )
+        + "\n"
+    )
+    mod.main()
+    payload = json.loads(mod.OUT.read_text())
+    assert payload["message"].startswith("42 / 200")


### PR DESCRIPTION
## TL;DR

The tracker was reporting **1248** — that's the raw file-hit count, not what Linguist actually grades on. The accurate unique-repo count is **109** today. This PR fixes the signal and makes the badge honest.

## Problem

Linguist's CONTRIBUTING.md requires "at least 200 unique `:user/:repo` repositories" using the language. We were displaying `total_count` from `/search/code?q=extension:ltl`, which is the **number of matching files** — one repo with 50 `.ltl` files contributes 50 to that number.

That means our "brightgreen 1248 / 200 ✅" badge was wildly over-reporting eligibility and gave us no real visibility into whether we were actually close to the bar.

## Fix

`count-ltl-repos.sh`:
- New `fetch_unique_repos()` that pages `/search/code` up to the 1000-item API ceiling and `sort -u`s `.items[].repository.full_name`
- Also records `repos_tagged` via `/search/repositories?q=language:Lateralus` — useful as a second signal once Linguist lands
- JSONL schema now includes `unique_repos` and `repos_tagged` alongside the existing `total` / `community` / `fallback`

`update_badge.py`:
- Signal preference: `unique_repos` → `repos_tagged` → `total` (last resort)
- Degrades gracefully on snapshots from before this patch

`tests/test_linguist_badge.py`:
- 3 new cases covering the preference ladder (now 7 passing total)

## Real numbers (live run against the API)

```
files=1248   <-- what we were showing
unique_repos=109   <-- what Linguist actually cares about
repos_tagged=0   <-- climbs once Linguist accepts the language
community=5616
```

So we're at **109 / 200** = **55%**, badge will drop from `brightgreen ✅` to `yellow`. That's the honest number and the one we should be tracking as we push the seed-repo count up.

## Follow-up

The seed-repos pipeline has 142 unpublished manifest entries — publishing those should take the unique-repo count well past 200. That's separate from this PR.
